### PR TITLE
Feature/parse only

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,7 @@ Fix
 Change
 ~~~~~~
 
+- Use click to parse the argument. [rachmadaniHaryono]
 - Change files to pass flake8 test. [rachmadaniHaryono]
 - Use Restructured text instead of Markdown file for readme.
 - All .gif files are saved as .mp4, [James T]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 New
 ~~~
 
+- Add `print only` feature. [rachmadaniHaryono]
 - Add `__init__.py` for tests folder so unit tests can run properly using pytest. [jtara1]
 - Add unit tests, now tests most common imgur links. [jtara1]
 - Add test py file for pytest. [jtara1]

--- a/imgurdownloader/imgurdownloader.py
+++ b/imgurdownloader/imgurdownloader.py
@@ -23,6 +23,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+import click
+
 __doc__ = """
 Quickly and easily download images from Imgur.
 
@@ -311,17 +313,19 @@ class ImgurDownloader:
         return True if data == dne_data else False
 
 
-def main():
-    args = sys.argv
-
-    if len(args) == 1:
+@click.command()
+@click.argument('url', nargs=1, required=False)
+@click.argument('destination_folder', nargs=1, required=False)
+def main(url, destination_folder):
+    """Quickly and easily download images from Imgur."""
+    if not url:
         # Print out the help message and exit:
         print(__doc__)
         exit()
 
     try:
         # Fire up the class:
-        downloader = ImgurDownloader(args[1])
+        downloader = ImgurDownloader(url)
 
         print(("Found {0} images in album".format(downloader.num_images())))
 
@@ -343,7 +347,7 @@ def main():
         downloader.on_complete(all_done)
 
         # Work out if we have a foldername or not:
-        if len(args) == 3:
+        if destination_folder:
             albumFolder = args[2]
         else:
             albumFolder = False

--- a/imgurdownloader/imgurdownloader.py
+++ b/imgurdownloader/imgurdownloader.py
@@ -19,7 +19,6 @@ import logging
 import math
 import os
 import re
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -155,7 +154,7 @@ class ImgurDownloader:
             self.cnt[i[1]] += 1
 
     def _init_image_ids_with_json(self, html):
-        """get section from html that contains image ID(s) and file extensions of each ID with json."""
+        """get html section that contains image ID(s) and file extensions of each ID with json."""
         """Format of the search variable.
         item: <java dict>\n};
         """
@@ -396,7 +395,7 @@ def main(url, destination_folder, print_only=False):
 
         # Work out if we have a foldername or not:
         if destination_folder:
-            albumFolder = args[2]
+            albumFolder = destination_folder
         else:
             albumFolder = False
 

--- a/imgurdownloader/imgurdownloader.py
+++ b/imgurdownloader/imgurdownloader.py
@@ -14,6 +14,7 @@ Copyright Alex Gisby <alex@solution10.com>
 
 from collections import Counter
 from urllib.error import HTTPError
+import json
 import logging
 import math
 import os
@@ -137,21 +138,13 @@ class ImgurDownloader:
         if self.debug:
             print('album_title: ' + self.album_title)  # debug
 
-        # get section from html that contains image ID(s) and file extensions of each ID
-        search = re.search('(item:.*?};)', html, flags=re.DOTALL)
-        if search:
-            # this'll fix those albums with one picture
-            if '"count"' in search.group(0):
-                search = re.search('"images".*?]', search.group(0), flags=re.DOTALL)
-            self.imageIDs = re.findall(
-                '.*?"hash":"([a-zA-Z0-9]+)".*?"ext":"(\.[a-zA-Z0-9]+)".*?',
-                search.group(0))
-            # removes the 1st element in imageIDs
-            # since this'll be the main_key if this link has more than 1 img
-            if len(self.imageIDs) > 1 and self.imageIDs[0][0] == self.main_key:
-                self.imageIDs.remove(self.imageIDs[0])
-        else:
-            raise Exception("Failed to find regex match in html")
+        image_ids = self._init_image_ids_with_regex(html=html)
+        if image_ids:
+            self.imageIDs = image_ids
+
+        json_image_ids = list(self._init_image_ids_with_json(html=html))
+        if json_image_ids:
+            self.json_imageIDs = json_image_ids
 
         if self.debug:
             print("imageIDs count: %s" % str(len(self.imageIDs)))  # debug
@@ -160,6 +153,51 @@ class ImgurDownloader:
         self.cnt = Counter()
         for i in self.imageIDs:
             self.cnt[i[1]] += 1
+
+    def _init_image_ids_with_json(self, html):
+        """get section from html that contains image ID(s) and file extensions of each ID with json."""
+        """Format of the search variable.
+        item: <java dict>\n};
+        """
+        image_ids = None
+        search_failed = False
+        search = re.search('(item:.*?};)', html, flags=re.DOTALL)
+        if search:
+            try:
+                search = search.group().replace('\n', '', ).split(':', 1)[1].rsplit('}', 1)[0]
+                json_search = json.loads(search)
+                img_dicts = json_search['album_images']['images']
+                for img_dict in img_dicts:
+                    # ext can be either '.jpg' or '.jpg?1'
+                    ext = \
+                        img_dict['ext'].split('?')[0] \
+                        if '?' in img_dict['ext'] else img_dict['ext']
+                    yield (img_dict['hash'], ext)
+            except Exception as e:
+                self.log.debug('JSON parse failed: {}'.format(e))
+                search_failed = True
+        if not search or search_failed:
+            raise Exception("Failed to find regex match in html")
+        return image_ids
+
+    def _init_image_ids_with_regex(self, html):
+        """get section from html that contains image ID(s) and file extensions of each ID."""
+        image_ids = None
+        search = re.search('(item:.*?};)', html, flags=re.DOTALL)
+        if search:
+            # this'll fix those albums with one picture
+            if '"count"' in search.group(0):
+                search = re.search('"images".*?]', search.group(0), flags=re.DOTALL)
+            image_ids = re.findall(
+                '.*?"hash":"([a-zA-Z0-9]+)".*?"ext":"(\.[a-zA-Z0-9]+)".*?',
+                search.group(0))
+            # removes the 1st element in imageIDs
+            # since this'll be the main_key if this link has more than 1 img
+            if len(image_ids) > 1 and image_ids[0][0] == self.main_key:
+                image_ids.remove(image_ids[0])
+        else:
+            raise Exception("Failed to find regex match in html")
+        return image_ids
 
     def num_images(self):
         """
@@ -314,9 +352,11 @@ class ImgurDownloader:
 
 
 @click.command()
+@click.option(
+    '--print-only', default=False, is_flag=True, help="Print download link only, no download.")
 @click.argument('url', nargs=1, required=False)
 @click.argument('destination_folder', nargs=1, required=False)
-def main(url, destination_folder):
+def main(url, destination_folder, print_only=False):
     """Quickly and easily download images from Imgur."""
     if not url:
         # Print out the help message and exit:
@@ -327,10 +367,11 @@ def main(url, destination_folder):
         # Fire up the class:
         downloader = ImgurDownloader(url)
 
-        print(("Found {0} images in album".format(downloader.num_images())))
+        if not print_only:
+            print(("Found {0} images in album".format(downloader.num_images())))
 
-        for i in downloader.list_extensions():
-            print(("Found {0} files with {1} extension".format(i[1], i[0])))
+            for i in downloader.list_extensions():
+                print(("Found {0} files with {1} extension".format(i[1], i[0])))
 
         # Called when an image is about to download:
         def print_image_progress(index, url, dest):
@@ -352,9 +393,13 @@ def main(url, destination_folder):
         else:
             albumFolder = False
 
-        # Enough talk, let's save!
-        downloader.save_images(albumFolder)
-        exit()
+        if not print_only:
+            # Enough talk, let's save!
+            downloader.save_images(albumFolder)
+        else:
+            for img_id, ext in downloader.json_imageIDs:
+                print('https://i.imgur.com/{}{}'.format(img_id, ext))
+        exit()  # NOTE: may not be needed
 
     except ImgurException as e:
         print(("Error: " + e.msg))

--- a/imgurdownloader/imgurdownloader.py
+++ b/imgurdownloader/imgurdownloader.py
@@ -166,13 +166,20 @@ class ImgurDownloader:
             try:
                 search = search.group().replace('\n', '', ).split(':', 1)[1].rsplit('}', 1)[0]
                 json_search = json.loads(search)
-                img_dicts = json_search['album_images']['images']
-                for img_dict in img_dicts:
-                    # ext can be either '.jpg' or '.jpg?1'
-                    ext = \
-                        img_dict['ext'].split('?')[0] \
-                        if '?' in img_dict['ext'] else img_dict['ext']
-                    yield (img_dict['hash'], ext)
+                if 'album_images' in json_search:
+                    img_dicts = json_search['album_images']['images']
+                    for img_dict in img_dicts:
+                        # ext can be either '.jpg' or '.jpg?1'
+                        ext = img_dict['ext']
+                        ext = ext.split('?')[0] if '?' in ext else ext
+                        yield (img_dict['hash'], ext)
+                elif 'hash' in json_search:
+                    # safe guard if any '?' in ext
+                    ext = json_search['ext']
+                    ext = ext.split('?')[0] if '?' in ext else ext
+                    return (json_search['hash'], json_search['ext'])
+                else:
+                    self.log.debug('Unknown json search key: {}'.format(json_search))
             except Exception as e:
                 self.log.debug('JSON parse failed: {}'.format(e))
                 search_failed = True

--- a/readme.rst
+++ b/readme.rst
@@ -25,6 +25,7 @@ jtara1 Fork - Features
 
     We don't have a blue backdrop, just tint the whole photo blue. (SnkkAVU).png
 
+- Add `--print-only` option to print the direct link of the imgur url.
 - Prevents downloading of imgur does not exist image if it is encountered.
   It is implemented by comparing the bytes of the HTTP request
   to that of a local imgur dne file in program.
@@ -113,19 +114,26 @@ Command Line Usage
 
 .. code:: bash
 
- $ imguralbum [album URL] [folder to save to]
+ $ imgurdownloader [album URL] [folder to save to]
 
 Download all images from an album into the folder /Users/alex/images/downloaded
 
 .. code:: bash
 
- $ imguralbum http://imgur.com/a/uOOju /Users/alex/images/downloaded
+ $ imgurdownloader http://imgur.com/a/uOOju /Users/alex/images/downloaded
 
 Downloads all images and puts them into an album in the current directory called "uOOju"
 
 .. code:: bash
 
- $ imguralbum http://imgur.com/a/uOOju
+ $ imgurdownloader http://imgur.com/a/uOOju
+
+
+It can also be used with downloader such as `wget` using `--print-only` option.
+
+.. code:: bash
+
+ imgurdownloader --print-only http://imgur.com/a/SVq41 | xargs wget
 
 
 Class Usage

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ try:
     long_description = open("readme.rst").read()
 except IOError:
     long_description = description
-
+install_requires=(
+    'click>=6.7',
+)
 setup(
     name="imgur_downloader",
     version="0.1.0",
@@ -18,7 +20,7 @@ setup(
     author_email='alex@solution10.com',
     url='https://github.com/jtara1/imgur_downloader',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=install_requires,
     long_description=long_description,
     classifiers=[
         "Programming Language :: Python",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ try:
     long_description = open("readme.rst").read()
 except IOError:
     long_description = description
-install_requires=(
+install_requires = (
     'click>=6.7',
 )
 setup(

--- a/tests/test_image_ids_and_extensions.py
+++ b/tests/test_image_ids_and_extensions.py
@@ -16,30 +16,33 @@ all_imgur_url_possibilities = [
 ]
 
 
-@pytest.mark.parametrize("url, id", [
-    ("http://imgur.com/SnkkAVU", [('SnkkAVU', '.png')]),
-    ('http://i.imgur.com/H37kxPH.jpg', [('H37kxPH', '.jpg')]),
-    ('http://imgur.com/gallery/40Uow1Q', [('40Uow1Q', '.jpg')]),
-    ('http://imgur.com/a/kfPrr', [('8sZQFxt', '.jpg')]),
-    ('http://imgur.com/r/awwnime/YldNww8', [('YldNww8', '.png')]),
-    (
-        'http://imgur.com/a/SVq41',
-        [
-            ('esSzNWQ', '.png'),
-            ('z25tnfF', '.png'),
-            ('eR27JxQ', '.png'),
-            ('tsGMdgr', '.png'),
-            ('cC0I2rs', '.png'),
-            ('SzqTvSx', '.gif')
-        ]
-    ),
-    ('http://i.imgur.com/MOvVbhc.gifv', [('MOvVbhc', '.gifv')]),
-    ('http://imgur.com/zvATqgs', [('zvATqgs', '.gif')]),
-    ('http://imgur.com/A61SaA1', [('A61SaA1', '.gif')]),
-])
-def test_image_ids_and_extensions(url, id):
+@pytest.mark.parametrize(
+    "url, exp_id", [
+        ("http://imgur.com/SnkkAVU", [('SnkkAVU', '.png')]),
+        ('http://i.imgur.com/H37kxPH.jpg', [('H37kxPH', '.jpg')]),
+        ('http://imgur.com/gallery/40Uow1Q', [('40Uow1Q', '.jpg')]),
+        ('http://imgur.com/a/kfPrr', [('8sZQFxt', '.jpg')]),
+        ('http://imgur.com/r/awwnime/YldNww8', [('YldNww8', '.png')]),
+        (
+            'http://imgur.com/a/SVq41',
+            [
+                ('esSzNWQ', '.png'),
+                ('z25tnfF', '.png'),
+                ('eR27JxQ', '.png'),
+                ('tsGMdgr', '.png'),
+                ('cC0I2rs', '.png'),
+                ('SzqTvSx', '.gif')
+            ]
+        ),
+        ('http://i.imgur.com/MOvVbhc.gifv', [('MOvVbhc', '.gifv')]),
+        ('http://imgur.com/zvATqgs', [('zvATqgs', '.gif')]),
+        ('http://imgur.com/A61SaA1', [('A61SaA1', '.gif')]),
+    ],
+)
+def test_image_ids_and_extensions(url, exp_id):
     imgur = ImgurDownloader(url)
-    assert(id == imgur.imageIDs)
+    assert(exp_id == imgur.json_imageIDs)
+    assert(exp_id == imgur.imageIDs)
 
 
 def test_gifv_gif_direct_link():

--- a/tests/test_image_ids_and_extensions.py
+++ b/tests/test_image_ids_and_extensions.py
@@ -1,4 +1,7 @@
 import os
+
+import pytest
+
 from imgurdownloader import ImgurDownloader
 
 
@@ -13,53 +16,35 @@ all_imgur_url_possibilities = [
 ]
 
 
-def test_single_img():
-    imgur = ImgurDownloader('http://imgur.com/SnkkAVU')
-    id = [('SnkkAVU', '.png')]
+@pytest.mark.parametrize("url, id", [
+    ("http://imgur.com/SnkkAVU", [('SnkkAVU', '.png')]),
+    ('http://i.imgur.com/H37kxPH.jpg', [('H37kxPH', '.jpg')]),
+    ('http://imgur.com/gallery/40Uow1Q', [('40Uow1Q', '.jpg')]),
+    ('http://imgur.com/a/kfPrr', [('8sZQFxt', '.jpg')]),
+    ('http://imgur.com/r/awwnime/YldNww8', [('YldNww8', '.png')]),
+    (
+        'http://imgur.com/a/SVq41',
+        [
+            ('esSzNWQ', '.png'),
+            ('z25tnfF', '.png'),
+            ('eR27JxQ', '.png'),
+            ('tsGMdgr', '.png'),
+            ('cC0I2rs', '.png'),
+            ('SzqTvSx', '.gif')
+        ]
+    ),
+    ('http://i.imgur.com/MOvVbhc.gifv', [('MOvVbhc', '.gifv')]),
+    ('http://imgur.com/zvATqgs', [('zvATqgs', '.gif')]),
+    ('http://imgur.com/A61SaA1', [('A61SaA1', '.gif')]),
+])
+def test_image_ids_and_extensions(url, id):
+    imgur = ImgurDownloader(url)
     assert(id == imgur.imageIDs)
-
-
-def test_single_direct_link_img():
-    imgur = ImgurDownloader('http://i.imgur.com/H37kxPH.jpg')
-    id = [('H37kxPH', '.jpg')]
-    assert(id == imgur.imageIDs)
-
-
-def test_single_img_in_gallery():
-    imgur = ImgurDownloader('http://imgur.com/gallery/40Uow1Q')
-    id = [('40Uow1Q', '.jpg')]
-    assert(id == imgur.imageIDs)
-
-
-def test_single_img_in_album():
-    imgur = ImgurDownloader('http://imgur.com/a/kfPrr')
-    # NOTE: the single image and the album have different identifiers
-    id = [('8sZQFxt', '.jpg')]
-    assert(id == imgur.imageIDs)
-
-
-def test_single_img_from_subreddit():
-    imgur = ImgurDownloader('http://imgur.com/r/awwnime/YldNww8')
-    id = [('YldNww8', '.png')]
-    assert(id == imgur.imageIDs)
-
-
-def test_album_multi_img_with_gifv():
-    imgur = ImgurDownloader('http://imgur.com/a/SVq41')
-    ids = [('esSzNWQ', '.png'),
-           ('z25tnfF', '.png'),
-           ('eR27JxQ', '.png'),
-           ('tsGMdgr', '.png'),
-           ('cC0I2rs', '.png'),
-           ('SzqTvSx', '.gif')]
-    assert(ids == imgur.imageIDs)
 
 
 def test_gifv_gif_direct_link():
     # since the extension is grabbed directly from the url, .gifv is the initial extension
     imgur = ImgurDownloader('http://i.imgur.com/MOvVbhc.gifv')
-    ids = [('MOvVbhc', '.gifv')]
-    assert (ids == imgur.imageIDs)
 
     # since the media is natively a video (.mp4) it is saved as such
     # NOTE: media downloaded is 1.4 MB
@@ -67,16 +52,3 @@ def test_gifv_gif_direct_link():
     file = os.path.join(os.getcwd(), 'MOvVbhc.mp4')
     assert(os.path.isfile(file))
     os.remove(file)
-
-
-def test_gifv_gif_normal_link():
-    imgur = ImgurDownloader('http://imgur.com/zvATqgs')
-    ids = [('zvATqgs', '.gif')]
-    assert(ids == imgur.imageIDs)
-    imgur2 = ImgurDownloader('http://imgur.com/A61SaA1')
-    ids2 = [('A61SaA1', '.gif')]
-    assert(ids2 == imgur2.imageIDs)
-
-
-if __name__ == "__main__":
-    test_single_img()


### PR DESCRIPTION
~~WIP~~

- add `print-only` option to print direct link from an album.
- add new extractor method using json library, see note below
- merge test using pytest parametrize
- fix args variable
- test json parsing
- add click dependancy
- readme explanation: new feature and xargs wget example
- test on all format for this json method.
- fix wrong cli command on readme

not yet commited
- ~`missing image test` on regex method (optional)~ skipped, use only the available imgur urls on test file. 

i test it using this imgur album http://imgur.com/a/stfnm (nsfw) and got different result between new method with json and old method with regex. maybe there is a way to double check the album using both method.

opinion @jtara1?

e: update after succesful test