### PR TITLE
fix: dev: unrelated error

### DIFF
--- a/imgurdownloader/imgurdownloader.py
+++ b/imgurdownloader/imgurdownloader.py
@@ -118,7 +118,10 @@ class ImgurDownloader:
             response_code = self.response.getcode()
         except Exception as e:
             self.response = False
-            response_code = e.code
+            try:
+                response_code = e.code
+            except AttributeError:
+                raise e
 
         if not self.response or self.response.getcode() != 200:
             raise ImgurException("[ImgurDownloader] HTTP Response Code %d" % response_code)


### PR DESCRIPTION
this is little fix for error that i met when my connection is bad 

```
➜  ~ imgurdownloader --print-only http://imgur.com/a/gb2sq
Traceback (most recent call last):
  File "/usr/lib/python3.5/urllib/request.py", line 1254, in do_open
    h.request(req.get_method(), req.selector, req.data, headers)
  File "/usr/lib/python3.5/http/client.py", line 1107, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.5/http/client.py", line 1152, in _send_request
    self.endheaders(body)
  File "/usr/lib/python3.5/http/client.py", line 1103, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python3.5/http/client.py", line 934, in _send_output
    self.send(msg)
  File "/usr/lib/python3.5/http/client.py", line 877, in send
    self.connect()
  File "/usr/lib/python3.5/http/client.py", line 849, in connect
    (self.host,self.port), self.timeout, self.source_address)
  File "/usr/lib/python3.5/socket.py", line 694, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
  File "/usr/lib/python3.5/socket.py", line 733, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/m/.git/imgur_downloader/imgurdownloader/imgurdownloader.py", line 117, in __init__
    self.response = urllib.request.urlopen(url=imgur_url)
  File "/usr/lib/python3.5/urllib/request.py", line 163, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.5/urllib/request.py", line 466, in open
    response = self._open(req, data)
  File "/usr/lib/python3.5/urllib/request.py", line 484, in _open
    '_open', req)
  File "/usr/lib/python3.5/urllib/request.py", line 444, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.5/urllib/request.py", line 1282, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.5/urllib/request.py", line 1256, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [Errno -2] Name or service not known>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/m/.local/bin/imgurdownloader", line 11, in <module>
    load_entry_point('imgur-downloader', 'console_scripts', 'imgurdownloader')()
  File "/home/m/.local/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/m/.local/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/m/.local/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/m/.local/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/m/.git/imgur_downloader/imgurdownloader/imgurdownloader.py", line 368, in main
    downloader = ImgurDownloader(url)
  File "/home/m/.git/imgur_downloader/imgurdownloader/imgurdownloader.py", line 121, in __init__
    response_code = e.code
AttributeError: 'URLError' object has no attribute 'code'
```