### PR TITLE
fix lint

### DIFF
--- a/imgurdownloader/imgurdownloader.py
+++ b/imgurdownloader/imgurdownloader.py
@@ -94,7 +94,7 @@ class ImgurDownloader:
             raise ImgurException("URL must be a valid Imgur Album")
 
         self.protocol = match.group(1)
-        domain_prefix = match.group(3)
+        # domain_prefix = match.group(3)
 
         imgur_link_type = match.group(4)
 


### PR DESCRIPTION
`domain_prefix` variable is assigned but never used