### PR TITLE
fix: truncate setup.cfg before rewriting its content

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ def update_cfg_module_name():
                           'name = {}'.format(module_name),
                           text)
             config.seek(0)
+            config.truncate()
             config.write(text)
     except (FileNotFoundError, FileExistsError):
         create_setup_cfg(update_cfg_module_name)


### PR DESCRIPTION
I was having problem installing **imgur_downloader** as a site package for my project on a Mac. Command `python setup.py egg_info` for the package was failing with this error:

```
Running command python setup.py egg_info
running egg_info
error: error in setup.cfg: command 'egg_info' has no such option 'n'
```

The `setup.cfg` in the tar.gz package did not have any abnormalities, but after running `python setup.py egg_info` it had an extra option at the end:

```
[metadata]
name = imgur_downloader
description-file = README.rst

[egg_info]
tag_build =
tag_date = 0
tag_svn_revision = 0

n = 0
```

After some troubleshooting of setup.py, I found that the problem happens in `update_cfg_module_name()` function. The problem happens because `setup.cfg` originally has CRLF line endings, but the new content that is replacing content of  `setup.cfg`  has LF line endings, which means that new content is shorter than old content, and it leaves `n = 0` from `tag_svn_revision = 0` untouched.

To solve the problem, I've added truncation of `setup.cfg` just before we write new content.